### PR TITLE
Fix up error handling

### DIFF
--- a/domapi.js
+++ b/domapi.js
@@ -254,60 +254,61 @@ function getDevs(passBack) {
                 idx: devID
             }, function (error, devices) {
                 var devArray = devices.results;
-                for (var i = 0; i < devArray.length; i++) {
+                if (devArray) {
+                    for (var i = 0; i < devArray.length; i++) {
 
-                    var device = devArray[i];
-                    var devType = device.type;
-                    var setswitch = device.switchType;
+                        var device = devArray[i];
+                        var devType = device.type;
+                        var setswitch = device.switchType;
 
-                    var appliancename = {
-                        applianceId: device.idx,
-                        manufacturerName: device.hardwareName,
-                        modelName: device.subType,
-                        version: device.switchType,
-                        friendlyName: device.name,
-                        friendlyDescription: devType,
-                        isReachable: true
-                    }
+                        var appliancename = {
+                            applianceId: device.idx,
+                            manufacturerName: device.hardwareName,
+                            modelName: device.subType,
+                            version: device.switchType,
+                            friendlyName: device.name,
+                            friendlyDescription: devType,
+                            isReachable: true
+                        }
 
-                    if (devType.startsWith("Light")) {
-                        appliancename.actions = ([
-                            "incrementPercentage",
-                            "decrementPercentage",
-                            "setPercentage",
-                            "turnOn",
-                            "turnOff"
-                        ])
-                        appliancename.additionalApplianceDetails = ({
-                            switchis: setswitch,
-                            WhatAmI: "light"
-                        })
-                        appliances.push(appliancename);
-                    }
-                    if (devType.startsWith("Blind")|| devType.startsWith("RFY")) {
-                        appliancename.actions = ([
-                            "turnOn",
-                            "turnOff"
-                        ])
-                        appliancename.additionalApplianceDetails = ({
-                            switchis: setswitch,
-                            WhatAmI: "blind"
-                        })
-                        appliances.push(appliancename);
-                    }
-                    else if (devType.startsWith("Temp")|| devType.startsWith("Therm")) {
-                        appliancename.version = "temp";
-                        appliancename.actions = ([
-                            "setTargetTemperature"
-                        ])
-                        appliancename.additionalApplianceDetails = ({
-                            WhatAmI: "temp"
-                        })
-                        appliances.push(appliancename);
+                        if (devType.startsWith("Light")) {
+                            appliancename.actions = ([
+                                "incrementPercentage",
+                                "decrementPercentage",
+                                "setPercentage",
+                                "turnOn",
+                                "turnOff"
+                            ])
+                            appliancename.additionalApplianceDetails = ({
+                                switchis: setswitch,
+                                WhatAmI: "light"
+                            })
+                            appliances.push(appliancename);
+                        }
+                        if (devType.startsWith("Blind")|| devType.startsWith("RFY")) {
+                            appliancename.actions = ([
+                                "turnOn",
+                                "turnOff"
+                            ])
+                            appliancename.additionalApplianceDetails = ({
+                                switchis: setswitch,
+                                WhatAmI: "blind"
+                            })
+                            appliances.push(appliancename);
+                        }
+                        else if (devType.startsWith("Temp")|| devType.startsWith("Therm")) {
+                            appliancename.version = "temp";
+                            appliancename.actions = ([
+                                "setTargetTemperature"
+                            ])
+                            appliancename.additionalApplianceDetails = ({
+                                WhatAmI: "temp"
+                            })
+                            appliances.push(appliancename);
+                        }
                     }
                 }
                 m--;
-
                 if (m==0) {
                     //log("payload: ", appliances);
                     var payloads = {

--- a/domapi.js
+++ b/domapi.js
@@ -408,20 +408,19 @@ function getRoomDevices(arrRoom, returnme){
             var DevsArray = callback.results;
             if (DevsArray == null){
                 console.log("no devices in room plans");
-                return
-            }
+            } else {
+                for (var i = 0; i < DevsArray.length; i++) {
+                    var device = DevsArray[i];
+                    //        log("device in room", device);
+                    var devIDX = device.devidx;
 
-            for (var i = 0; i < DevsArray.length; i++) {
-                var device = DevsArray[i];
-                //        log("device in room", device);
-                var devIDX = device.devidx;
-
-                // DeviceIDs.push(devIDX);
-                if (device.type === 1){
-                    GroupIDs.push(devIDX)
-                }
-                else if (device.type === 0){
-                    DeviceIDs.push(devIDX);
+                    // DeviceIDs.push(devIDX);
+                    if (device.type === 1){
+                        GroupIDs.push(devIDX)
+                    }
+                    else if (device.type === 0){
+                        DeviceIDs.push(devIDX);
+                    }
                 }
             }
             k--;


### PR DESCRIPTION
When rooms are empty or when devices are unavailable to the authenticated user, don't forget to return the other results.